### PR TITLE
dbus server accepts parsing blur strength and added dbus example

### DIFF
--- a/dbus-examples/dbus-strength.sh
+++ b/dbus-examples/dbus-strength.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+if [ "$#" -eq 1 ]; then
+    echo "Illegal number of parameters: blur strength is required"
+fi
+
+strength="$@"
+
+if [ -z "$SED" ]; then
+  SED="sed"
+  command -v gsed > /dev/null && SED="gsed"
+fi
+
+# === Get connection parameters ===
+
+dpy=$(echo -n "$DISPLAY" | tr -c '[:alnum:]' _)
+
+if [ -z "$dpy" ]; then
+  echo "Cannot find display."
+  exit 1
+fi
+
+service="com.github.chjj.compton.${dpy}"
+interface='com.github.chjj.compton'
+object='/com/github/chjj/compton'
+type_win='uint32'
+type_enum='uint16'
+
+# === DBus methods ===
+
+# List all window ID compton manages (except destroyed ones)
+dbus-send --print-reply --dest="$service" "$object" "${interface}.list_win"
+
+# Ensure we are tracking focus
+dbus-send --print-reply --dest="$service" "$object" "${interface}.opts_set" string:track_focus boolean:true
+
+# Get window ID of currently focused window
+focused=$(dbus-send --print-reply --dest="$service" "$object" "${interface}.find_win" string:focused | $SED -n 's/^[[:space:]]*'${type_win}'[[:space:]]*\([[:digit:]]*\).*/\1/p')
+
+if [ -n "$focused" ]; then
+  if [[ "${strength:0:1}" =~ [+-] ]]; then
+    # Increment the window to have selected strength
+    dbus-send --print-reply --dest="$service" "$object" "${interface}.win_set" "${type_win}:${focused}" string:inc_blur_strength "${type_enum}:$strength"
+  else
+    # Set the window to have selected strength
+    dbus-send --print-reply --dest="$service" "$object" "${interface}.win_set" "${type_win}:${focused}" string:set_blur_strength "${type_enum}:$strength"
+  fi
+else
+  echo "Cannot find focused window."
+fi

--- a/src/common.h
+++ b/src/common.h
@@ -551,10 +551,12 @@ struct _timeout_t;
 
 struct _win;
 
-typedef struct {
-  int iterations;
-  float offset;
-} blur_strength_t;
+typedef struct { 
+   int level; 
+   int iterations; 
+   float offset; 
+   int expand; 
+} blur_strength_t; 
 
 typedef struct _c2_lptr c2_lptr_t;
 
@@ -1711,29 +1713,28 @@ parse_blur_method(session_t *ps, const char *str) {
  */
 static inline bool
 parse_blur_strength(session_t *ps, const int level) {
-  static const blur_strength_t values[20] = {
-    { .iterations = 1, .offset = 1.5 },     // 1
-    { .iterations = 1, .offset = 2.0 },     // 2
-    { .iterations = 2, .offset = 2.5 },     // 3
-    { .iterations = 2, .offset = 3.0 },     // 4
-    { .iterations = 3, .offset = 2.75 },    // 5
-    { .iterations = 3, .offset = 3.5 },     // 6
-    { .iterations = 3, .offset = 4.25 },    // 7
-    { .iterations = 3, .offset = 5.0 },     // 8
-    { .iterations = 4, .offset = 3.71429 }, // 9
-    { .iterations = 4, .offset = 4.42857 }, // 10
-    { .iterations = 4, .offset = 5.14286 }, // 11
-    { .iterations = 4, .offset = 5.85714 }, // 12
-    { .iterations = 4, .offset = 6.57143 }, // 13
-    { .iterations = 4, .offset = 7.28571 }, // 14
-    { .iterations = 4, .offset = 8.0 },     // 15
-    { .iterations = 5, .offset = 6.0 },     // 16
-    { .iterations = 5, .offset = 7.0 },     // 17
-    { .iterations = 5, .offset = 8.0 },     // 18
-    { .iterations = 5, .offset = 9.0 },     // 19
-    { .iterations = 5, .offset = 10.0 },    // 20
-  };
-
+  static const blur_strength_t values[20] = { 
+    { .level =  1, .iterations = 1, .offset =  1.5    , .expand = 10 }, // 1 
+    { .level =  2, .iterations = 1, .offset =  2.0    , .expand = 10 }, // 2 
+    { .level =  3, .iterations = 2, .offset =  2.5    , .expand = 20 }, // 3 
+    { .level =  4, .iterations = 2, .offset =  3.0    , .expand = 20 }, // 4 
+    { .level =  5, .iterations = 3, .offset =  2.75   , .expand = 50 }, // 5 
+    { .level =  6, .iterations = 3, .offset =  3.5    , .expand = 50 }, // 6 
+    { .level =  7, .iterations = 3, .offset =  4.25   , .expand = 50 }, // 7 
+    { .level =  8, .iterations = 3, .offset =  5.0    , .expand = 50 }, // 8 
+    { .level =  9, .iterations = 4, .offset =  3.71429, .expand = 150 }, // 9 
+    { .level = 10, .iterations = 4, .offset =  4.42857, .expand = 150 }, // 10 
+    { .level = 11, .iterations = 4, .offset =  5.14286, .expand = 150 }, // 11 
+    { .level = 12, .iterations = 4, .offset =  5.85714, .expand = 150 }, // 12 
+    { .level = 13, .iterations = 4, .offset =  6.57143, .expand = 150 }, // 13 
+    { .level = 14, .iterations = 4, .offset =  7.28571, .expand = 150 }, // 14 
+    { .level = 15, .iterations = 4, .offset =  8.0    , .expand = 150 }, // 15 
+    { .level = 16, .iterations = 5, .offset =  6.0    , .expand = 400 }, // 16 
+    { .level = 17, .iterations = 5, .offset =  7.0    , .expand = 400 }, // 17 
+    { .level = 18, .iterations = 5, .offset =  8.0    , .expand = 400 }, // 18 
+    { .level = 19, .iterations = 5, .offset =  9.0    , .expand = 400 }, // 19 
+    { .level = 20, .iterations = 5, .offset = 10.0    , .expand = 400 }, // 20 
+  }; 
   if (level < 1 || level > 20) {
     printf_errf("(\"%d\"): Invalid blur_strength argument. Needs to be a number between 1 and 20.", level);
     return false;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1,3 +1,4 @@
+
 /*
  * Compton - a compositor for X11
  *
@@ -817,6 +818,23 @@ cdbus_process_win_set(session_t *ps, DBusMessage *msg) {
     if (!cdbus_msg_get_arg(msg, 2, CDBUS_TYPE_ENUM, &val))
       return false;
     win_set_invert_color_force(ps, w, val);
+    goto cdbus_process_win_set_success;
+  }
+
+  if (!strcmp("set_blur_strength", target)) {
+    cdbus_enum_t val = UNSET;
+    if (!cdbus_msg_get_arg(msg, 2, CDBUS_TYPE_ENUM, &val))
+      return false;
+    parse_blur_strength(ps, val);
+    goto cdbus_process_win_set_success;
+  }
+
+  if (!strcmp("inc_blur_strength", target)) {
+    cdbus_enum_t val = UNSET;
+    if (!cdbus_msg_get_arg(msg, 2, CDBUS_TYPE_ENUM, &val))
+      return false;
+    int signed_val = val == 65535 ? -1 : 1;
+    parse_blur_strength(ps, ps->o.blur_strength.level + signed_val);
     goto cdbus_process_win_set_success;
   }
 #undef cdbus_m_win_set_do


### PR DESCRIPTION
This one doesn't bloat stuff up and solves #14 

I'm still wondering though, can we omit the `parse_blur_strength` call?