### PR TITLE
Fix bug where --frame-opacity and --experimental-backends causes picom to become unusable.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ Adam Jackson <ajax@nwnk.net>
 Alexander Kapshuna <kapsh@kap.sh>
 Antonin Décimo <antonin.decimo@gmail.com>
 Avi-D-coder <avi.the.coder@gmail.com>
+Bernd Busse <tryone144@bussenet.de>
 Brottweiler <tibell.christoffer@gmail.com>
 Carl Worth <cworth@cworth.org>
 Christopher Jeffrey <chjjeffrey@gmail.com>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ picom
 
 **This is a development branch, bugs to be expected**
 
+**[WIP] Merge-branch for the *dual_kawase* blur shader**
+
+This branch includes a new blur method: The fast and good-looking *dual-filter kawase blur*! Use it with `--blur-method dual_kawase` and configure it with `--blur-strength LEVEL`. Only works with `--experimental-backends` and `--backend glx`!
+
 This is forked from the original Compton because it seems to have become unmaintained.
 
 The current battle plan of this fork is to refactor it to make the code _possible_ to maintain, so potential contributors won't be scared away when they take a look at the code.

--- a/man/picom.1.asciidoc
+++ b/man/picom.1.asciidoc
@@ -166,7 +166,7 @@ OPTIONS
 *--detect-client-leader*::
 	Use 'WM_CLIENT_LEADER' to group windows, and consider windows in the same group focused at the same time. 'WM_TRANSIENT_FOR' has higher priority if *--detect-transient* is enabled, too.
 
-*--blur-method*, *--blur-size*, *--blur-deviation*::
+*--blur-method*, *--blur-size*, *--blur-deviation*, *--blur-strength*::
 	Parameters for background blurring, see the *BLUR* section for more information.
 
 *--blur-background*::
@@ -397,14 +397,17 @@ Available options of the 'blur' section are: ::
 
   *method*:::
     A string. Controls the blur method. Corresponds to the *--blur-method* command line option. Available choices are:
-      'none' to disable blurring; 'gaussian' for gaussian blur; 'box' for box blur; 'kernel' for convolution blur with a custom kernel.
-    Note: 'gaussian' and 'box' blur methods are only supported by the experimental backends.
+      'none' to disable blurring; 'gaussian' for gaussian blur; 'box' for box blur; 'kernel' for convolution blur with a custom kernel; 'dual_kawase' for dual-filter kawase blur.
+    Note: 'gaussian', 'box' and 'dual_kawase' blur methods are only supported by the experimental backends.
 
   *size*:::
     An integer. The size of the blur kernel, required by 'gaussian' and 'box' blur methods. For the 'kernel' method, the size is included in the kernel. Corresponds to the *--blur-size* command line option.
 
   *deviation*:::
     A floating point number. The standard deviation for the 'gaussian' blur method. Corresponds to the *--blur-deviation* command line option.
+
+  *strength*:::
+    An integer in the range 1-20. The strength of the 'dual_kawase' blur method. Corresponds to the *--blur-strength* command line option. If not specified, the value requested by *--blur-size* is approximated.
 
   *kernel*:::
     A string. The kernel to use for the 'kernel' blur method, specified in the same format as the *--blur-kerns* option. Corresponds to the *--blur-kerns* command line option.

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -211,6 +211,9 @@ void paint_all_new(session_t *ps, struct managed_win *t, bool ignore_damage) {
 				// fading out.
 				blur_opacity =
 				    w->opacity / win_calc_opacity_target(ps, w, true);
+			} else if (!ps->o.blur_background_fixed) {
+				// Apply blur intensity depending on the window opacity.
+				blur_opacity = w->opacity;
 			}
 
 			if (real_win_mode == WMODE_TRANS || ps->o.force_win_blend) {

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -65,6 +65,11 @@ struct kernel_blur_args {
 	int kernel_count;
 };
 
+struct dual_kawase_blur_args {
+	int size;
+	int strength;
+};
+
 struct backend_operations {
 	// ===========    Initialization    ===========
 

--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) Yuxuan Shui <yshuiv7@gmail.com>
-#include <string.h>
 #include <math.h>
+#include <string.h>
 #include <xcb/render.h>
 #include <xcb/xcb_image.h>
 #include <xcb/xcb_renderutil.h>
@@ -9,10 +9,10 @@
 #include "backend/backend.h"
 #include "backend/backend_common.h"
 #include "common.h"
-#include "kernel.h"
 #include "config.h"
-#include "utils.h"
+#include "kernel.h"
 #include "log.h"
+#include "utils.h"
 #include "win.h"
 #include "x.h"
 
@@ -283,8 +283,7 @@ default_backend_render_shadow(backend_t *backend_data, int width, int height,
 	return ret;
 }
 
-static struct conv **
-generate_box_blur_kernel(struct box_blur_args *args, int *kernel_count) {
+static struct conv **generate_box_blur_kernel(struct box_blur_args *args, int *kernel_count) {
 	int r = args->size * 2 + 1;
 	assert(r > 0);
 	auto ret = ccalloc(2, struct conv *);
@@ -334,6 +333,20 @@ struct conv **generate_blur_kernel(enum blur_method method, void *args, int *ker
 	default: break;
 	}
 	return NULL;
+}
+
+/// Generate kernel parameters for dual-kawase blur method. Falls back on approximating
+/// standard gauss radius if strength is not supplied
+struct dual_kawase_params *generate_dual_kawase_params(void *args) {
+	struct dual_kawase_blur_args *blur_args = args;
+
+	// TODO: create real parameters from supplied arguments
+	auto params = ccalloc(1, struct dual_kawase_params);
+	params->iterations = 3;
+	params->offset = 3.25f;
+	params->expand = 20;
+
+	return params;
 }
 
 void init_backend_base(struct backend_base *base, session_t *ps) {

--- a/src/backend/backend_common.c
+++ b/src/backend/backend_common.c
@@ -339,12 +339,90 @@ struct conv **generate_blur_kernel(enum blur_method method, void *args, int *ker
 /// standard gauss radius if strength is not supplied
 struct dual_kawase_params *generate_dual_kawase_params(void *args) {
 	struct dual_kawase_blur_args *blur_args = args;
+	static const struct {
+		int iterations;
+		float offset;
+	} strength_levels[20] = {
+	    {.iterations = 1, .offset = 1.25f},        // LVL  1 => radius   4
+	    {.iterations = 1, .offset = 2.25f},        // LVL  2 => radius   7
+	    {.iterations = 2, .offset = 2.00f},        // LVL  3 => radius  14
+	    {.iterations = 2, .offset = 3.00f},        // LVL  4 => radius  20
+	    {.iterations = 2, .offset = 4.25f},        // LVL  5 => radius  28
+	    {.iterations = 3, .offset = 2.50f},        // LVL  6 => radius  35
+	    {.iterations = 3, .offset = 3.25f},        // LVL  7 => radius  45
+	    {.iterations = 3, .offset = 4.25f},        // LVL  8 => radius  57
+	    {.iterations = 3, .offset = 5.50f},        // LVL  9 => radius  74
+	    {.iterations = 4, .offset = 3.25f},        // LVL 10 => radius  91
+	    {.iterations = 4, .offset = 4.00f},        // LVL 11 => radius 110
+	    {.iterations = 4, .offset = 5.00f},        // LVL 12 => radius 135
+	    {.iterations = 4, .offset = 6.00f},        // LVL 13 => radius 161
+	    {.iterations = 4, .offset = 7.25f},        // LVL 14 => radius 195
+	    {.iterations = 4, .offset = 8.25f},        // LVL 15 => radius 221
+	    {.iterations = 5, .offset = 4.50f},        // LVL 16 => radius 250
+	    {.iterations = 5, .offset = 5.25f},        // LVL 17 => radius 287
+	    {.iterations = 5, .offset = 6.25f},        // LVL 18 => radius 330
+	    {.iterations = 5, .offset = 7.25f},        // LVL 19 => radius 383
+	    {.iterations = 5, .offset = 8.50f},        // LVL 20 => radius >450
+	};
 
-	// TODO: create real parameters from supplied arguments
 	auto params = ccalloc(1, struct dual_kawase_params);
-	params->iterations = 3;
-	params->offset = 3.25f;
-	params->expand = 20;
+	params->iterations = 0;
+	params->offset = 1.0f;
+
+	if (blur_args->strength <= 0 && blur_args->size) {
+		// approximate blur_strength with gaussian blur_radius
+		if (blur_args->size < 6) {
+			blur_args->strength = 1;
+		} else if (blur_args->size < 11) {
+			blur_args->strength = 2;
+		} else if (blur_args->size < 17) {
+			blur_args->strength = 3;
+		} else if (blur_args->size < 24) {
+			blur_args->strength = 4;
+		} else if (blur_args->size < 32) {
+			blur_args->strength = 5;
+		} else if (blur_args->size < 40) {
+			blur_args->strength = 6;
+		} else if (blur_args->size < 51) {
+			blur_args->strength = 7;
+		} else if (blur_args->size < 67) {
+			blur_args->strength = 8;
+		} else if (blur_args->size < 83) {
+			blur_args->strength = 9;
+		} else if (blur_args->size < 101) {
+			blur_args->strength = 10;
+		} else if (blur_args->size < 123) {
+			blur_args->strength = 11;
+		} else if (blur_args->size < 148) {
+			blur_args->strength = 12;
+		} else if (blur_args->size < 177) {
+			blur_args->strength = 13;
+		} else if (blur_args->size < 208) {
+			blur_args->strength = 14;
+		} else if (blur_args->size < 236) {
+			blur_args->strength = 15;
+		} else if (blur_args->size < 269) {
+			blur_args->strength = 16;
+		} else if (blur_args->size < 309) {
+			blur_args->strength = 17;
+		} else if (blur_args->size < 357) {
+			blur_args->strength = 18;
+		} else if (blur_args->size < 417) {
+			blur_args->strength = 19;
+		} else {
+			blur_args->strength = 20;
+		}
+	}
+
+	if (blur_args->strength > 0) {
+		assert(blur_args->strength <= 20);
+		params->iterations = strength_levels[blur_args->strength - 1].iterations;
+		params->offset = strength_levels[blur_args->strength - 1].offset;
+	}
+
+	params->expand = 2 * (int)exp2f((float)params->iterations) *
+	                     (256 - (int)(256.0f - params->offset)) +
+	                 1;
 
 	return params;
 }

--- a/src/backend/backend_common.h
+++ b/src/backend/backend_common.h
@@ -16,6 +16,15 @@ typedef struct conv conv;
 typedef struct backend_base backend_t;
 struct backend_operations;
 
+struct dual_kawase_params {
+	/// Number of downsample passes
+	int iterations;
+	/// Pixel offset for down- and upsample
+	float offset;
+	/// Save area around blur target (@ref resize_width, @ref resize_height)
+	int expand;
+};
+
 bool build_shadow(xcb_connection_t *, xcb_drawable_t, double opacity, int width,
                   int height, const conv *kernel, xcb_render_picture_t shadow_pixel,
                   xcb_pixmap_t *pixmap, xcb_render_picture_t *pict);
@@ -41,3 +50,5 @@ default_backend_render_shadow(backend_t *backend_data, int width, int height,
 void init_backend_base(struct backend_base *base, session_t *ps);
 
 struct conv **generate_blur_kernel(enum blur_method method, void *args, int *kernel_count);
+
+struct dual_kawase_params *generate_dual_kawase_params(void *args);

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1092,7 +1092,7 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 		// the single pass case
 		auto pass = &ctx->blur_shader[1];
 		pass->prog = gl_create_program_from_str(vertex_shader, dummy_frag);
-		pass->unifm_opacity = glGetUniformLocationChecked(pass->prog, "opacity");
+		pass->unifm_opacity = -1;
 		pass->orig_loc = glGetUniformLocationChecked(pass->prog, "orig");
 		pass->texorig_loc = glGetUniformLocationChecked(pass->prog, "texorig");
 		ctx->npasses = 2;

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -990,6 +990,12 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 		return ctx;
 	}
 
+	if (method == BLUR_METHOD_DUAL_KAWASE) {
+		log_warn("Blur method 'dual_kawase' is not yet implemented.");
+		ctx->method = BLUR_METHOD_NONE;
+		return ctx;
+	}
+
 	int nkernels;
 	ctx->method = BLUR_METHOD_KERNEL;
 	if (method == BLUR_METHOD_KERNEL) {

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1761,8 +1761,9 @@ static inline void gl_image_decouple(backend_t *base, struct gl_image *img) {
 
 static void gl_image_apply_alpha(backend_t *base, struct gl_image *img,
                                  const region_t *reg_op, double alpha) {
-	glBlendFunc(GL_ONE, GL_CONSTANT_COLOR);
-	glBlendColor((GLclampf)alpha, (GLclampf)alpha, (GLclampf)alpha, (GLclampf)alpha);
+	// Result color = 0 (GL_ZERO) + alpha (GL_CONSTANT_ALPHA) * original color
+	glBlendFunc(GL_ZERO, GL_CONSTANT_ALPHA);
+	glBlendColor(0, 0, 0, (GLclampf)alpha);
 	GLuint fbo;
 	glGenFramebuffers(1, &fbo);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -215,6 +215,8 @@ _gl_average_texture_color(backend_t *base, GLuint source_texture, GLuint destina
 	const int to_width = from_width > max_width ? from_width / 2 : from_width;
 	const int to_height = from_height > max_height ? from_height / 2 : from_height;
 
+	glViewport(0, 0, width, height);
+
 	// Prepare coordinates
 	GLint coord[] = {
 	    // top left
@@ -403,6 +405,7 @@ static void _gl_compose(backend_t *base, struct gl_image *img, GLuint target,
 	//          x, y, width, height, dx, dy, ptex->width, ptex->height, z);
 
 	// Bind texture
+	glViewport(0, 0, gd->width, gd->height);
 	glActiveTexture(GL_TEXTURE1);
 	glBindTexture(GL_TEXTURE_2D, brightness);
 	glActiveTexture(GL_TEXTURE0);
@@ -979,7 +982,6 @@ static int gl_win_shader_from_string(const char *vshader_str, const char *fshade
  * Callback to run on root window size change.
  */
 void gl_resize(struct gl_data *gd, int width, int height) {
-	glViewport(0, 0, width, height);
 	gd->height = height;
 	gd->width = width;
 
@@ -1798,6 +1800,7 @@ void gl_present(backend_t *base, const region_t *region) {
 		       sizeof(GLuint) * 6);
 	}
 
+	glViewport(0, 0, gd->width, gd->height);
 	glUseProgram(gd->present_prog);
 	glBindTexture(GL_TEXTURE_2D, gd->back_texture);
 

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -32,14 +32,24 @@ struct gl_blur_context {
 	enum blur_method method;
 	gl_blur_shader_t *blur_shader;
 
+	// TODO: allocate blur_texture and blur_fbo dynamically to allow for as many
+	// iterations as required
 	/// Temporary textures used for blurring. They are always the same size as the
 	/// target, so they are always big enough without resizing.
 	/// Turns out calling glTexImage to resize is expensive, so we avoid that.
-	GLuint blur_texture[2];
+	GLuint blur_texture[5];
 	/// Temporary fbo used for blurring
-	GLuint blur_fbo;
+	GLuint blur_fbo[5];
+	/// Cached size of each `blur_texture`
+	struct {
+		int width;
+		int height;
+	} texture_size[5];
 
-	int texture_width, texture_height;
+	int blur_texture_count;
+	int blur_fbo_count;
+
+	int fb_width, fb_height;
 
 	/// How much do we need to resize the damaged region for blurring.
 	int resize_width, resize_height;
@@ -543,7 +553,7 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 	struct gl_data *gd = (void *)base;
 
 	int dst_y_screen_coord = gd->height - extent->y2,
-	    dst_y_fb_coord = bctx->texture_height - extent->y2;
+	    dst_y_fb_coord = bctx->fb_height - extent->y2;
 
 	int curr = 0;
 	for (int i = 0; i < bctx->npasses; ++i) {
@@ -571,7 +581,7 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 		if (i < bctx->npasses - 1) {
 			// not last pass, draw into framebuffer, with resized regions
 			glBindVertexArray(vao[1]);
-			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[0]);
 
 			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
 			                       GL_TEXTURE_2D, bctx->blur_texture[!curr], 0);
@@ -585,7 +595,7 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 
 			glUniform2f(p->orig_loc, (GLfloat)bctx->resize_width,
 			            -(GLfloat)bctx->resize_height);
-			glViewport(0, 0, bctx->texture_width, bctx->texture_height);
+			glViewport(0, 0, bctx->fb_width, bctx->fb_height);
 		} else {
 			// last pass, draw directly into the back buffer, with origin
 			// regions
@@ -615,9 +625,139 @@ bool gl_dual_kawase_blur(backend_t *base, double opacity, void *ctx, const rect_
 	struct gl_blur_context *bctx = ctx;
 	struct gl_data *gd = (void *)base;
 
-	// TODO: Blur with dual_kawase shaders
+	int dst_y_screen_coord = gd->height - extent->y2,
+	    dst_y_fb_coord = bctx->fb_height - extent->y2;
 
-	return false;
+	// Note: OpenGL matrices are column major
+	GLfloat projection_matrix[4][4] = {{2.0f / (GLfloat)bctx->fb_width, 0, 0, 0},
+	                                   {0, 2.0f / (GLfloat)bctx->fb_height, 0, 0},
+	                                   {0, 0, 0, 0},
+	                                   {-1, -1, 0, 1}};
+
+	// Kawase downsample pass
+	const gl_blur_shader_t *down_pass = &bctx->blur_shader[0];
+	assert(down_pass->prog);
+	glUseProgram(down_pass->prog);
+
+	// Update projection matrices in the blur shaders
+	glUniformMatrix4fv(down_pass->projection_loc, 1, false, projection_matrix[0]);
+	glUniform2f(down_pass->orig_loc, (GLfloat)bctx->resize_width,
+	            -(GLfloat)bctx->resize_height);
+
+	for (int i = 0; i < bctx->blur_texture_count; ++i) {
+		GLuint src_texture;
+		int tex_width, tex_height;
+		int texorig_x, texorig_y;
+
+		float halfpixel_x, halfpixel_y;
+
+		if (i == 0) {
+			// first pass: copy from back buffer
+			src_texture = gd->back_texture;
+			tex_width = gd->width;
+			tex_height = gd->height;
+
+			texorig_x = extent->x1;
+			texorig_y = dst_y_screen_coord;
+
+			halfpixel_x = 0.5f / (float)gd->width;
+			halfpixel_y = 0.5f / (float)gd->height;
+		} else {
+			// copy from previous pass
+			src_texture = bctx->blur_texture[i - 1];
+			tex_width = bctx->fb_width;
+			tex_height = bctx->fb_height;
+
+			texorig_x = extent->x1 + bctx->resize_width;
+			texorig_y = dst_y_fb_coord - bctx->resize_height;
+
+			auto src_size = bctx->texture_size[i - 1];
+			halfpixel_x = 0.5f / (float)src_size.width;
+			halfpixel_y = 0.5f / (float)src_size.height;
+		}
+
+		glBindTexture(GL_TEXTURE_2D, src_texture);
+		glBindVertexArray(vao[1]);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i]);
+		glDrawBuffer(GL_COLOR_ATTACHMENT0);
+
+		glUniform2f(down_pass->texorig_loc, (GLfloat)texorig_x, (GLfloat)texorig_y);
+		glUniform2f(down_pass->unifm_texture_size, (GLfloat)tex_width,
+		            (GLfloat)tex_height);
+		glUniform2f(down_pass->unifm_halfpixel, halfpixel_x, halfpixel_y);
+
+		auto tgt_size = bctx->texture_size[i];
+		glViewport(0, 0, tgt_size.width, tgt_size.height);
+		glDrawElements(GL_TRIANGLES, nrects * 6, GL_UNSIGNED_INT, NULL);
+	}
+
+	// Kawase upsample pass
+	const gl_blur_shader_t *up_pass = &bctx->blur_shader[1];
+	assert(up_pass->prog);
+	glUseProgram(up_pass->prog);
+
+	// Update projection matrices in the blur shaders
+	glUniformMatrix4fv(up_pass->projection_loc, 1, false, projection_matrix[0]);
+
+	glUniform2f(up_pass->texorig_loc, (GLfloat)(extent->x1 + bctx->resize_width),
+	            (GLfloat)(dst_y_fb_coord - bctx->resize_height));
+	glUniform2f(up_pass->unifm_texture_size, (GLfloat)bctx->fb_width,
+	            (GLfloat)bctx->fb_height);
+
+	for (int i = bctx->blur_texture_count - 1; i >= 0; --i) {
+		const GLuint src_texture = bctx->blur_texture[i];
+		int orig_x, orig_y;
+
+		auto src_size = bctx->texture_size[i];
+		float halfpixel_x = 0.5f / (float)src_size.width,
+		      halfpixel_y = 0.5f / (float)src_size.height;
+
+		int vp_width, vp_height;
+
+		glBindTexture(GL_TEXTURE_2D, src_texture);
+		if (i > 0) {
+			// not last pass, draw into next framebuffer
+			glBindVertexArray(vao[1]);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i - 1]);
+			glDrawBuffer(GL_COLOR_ATTACHMENT0);
+			glClearBufferiv(GL_COLOR, 0, (GLint[4]){255, 0, 0, 255});
+
+			orig_x = bctx->resize_width;
+			orig_y = -bctx->resize_height;
+
+			auto tgt_size = bctx->texture_size[i - 1];
+			vp_width = tgt_size.width;
+			vp_height = tgt_size.height;
+
+			glUniform1f(up_pass->unifm_opacity, (GLfloat)1);
+		} else {
+			// last pass, draw directly into the back buffer
+			glBindVertexArray(vao[0]);
+			glBindFramebuffer(GL_FRAMEBUFFER, gd->back_fbo);
+
+			// Update projection matrix
+			projection_matrix[0][0] = 2.0f / (GLfloat)gd->width;
+			projection_matrix[1][1] = 2.0f / (GLfloat)gd->height;
+			glUniformMatrix4fv(up_pass->projection_loc, 1, false,
+			                   projection_matrix[0]);
+
+			orig_x = 0;
+			orig_y = 0;
+
+			vp_width = gd->width;
+			vp_height = gd->height;
+
+			glUniform1f(up_pass->unifm_opacity, (GLfloat)opacity);
+		}
+
+		glUniform2f(up_pass->orig_loc, (GLfloat)orig_x, (GLfloat)orig_y);
+		glUniform2f(up_pass->unifm_halfpixel, halfpixel_x, halfpixel_y);
+
+		glViewport(0, 0, vp_width, vp_height);
+		glDrawElements(GL_TRIANGLES, nrects * 6, GL_UNSIGNED_INT, NULL);
+	}
+
+	return true;
 }
 
 bool gl_blur(backend_t *base, double opacity, void *ctx, const region_t *reg_blur,
@@ -627,28 +767,51 @@ bool gl_blur(backend_t *base, double opacity, void *ctx, const region_t *reg_blu
 
 	bool ret = false;
 
-	if (gd->width + bctx->resize_width * 2 != bctx->texture_width ||
-	    gd->height + bctx->resize_height * 2 != bctx->texture_height) {
+	if (gd->width + bctx->resize_width * 2 != bctx->fb_width ||
+	    gd->height + bctx->resize_height * 2 != bctx->fb_height) {
 		// Resize the temporary textures used for blur in case the root
 		// size changed
-		bctx->texture_width = gd->width + bctx->resize_width * 2;
-		bctx->texture_height = gd->height + bctx->resize_height * 2;
+		bctx->fb_width = gd->width + bctx->resize_width * 2;
+		bctx->fb_height = gd->height + bctx->resize_height * 2;
 
 		if (bctx->method == BLUR_METHOD_DUAL_KAWASE) {
-			// TODO: Use smaller textures for each iteration
+			// Use smaller textures for each iteration
+			for (int i = 0; i < bctx->blur_texture_count; ++i) {
+				auto tex_size = bctx->texture_size + i;
+				tex_size->width = 1 + (bctx->fb_width - 1) / (1 << (i + 1));
+				tex_size->height = 1 + (bctx->fb_height - 1) / (1 << (i + 1));
+
+				glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[i]);
+				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, tex_size->width,
+				             tex_size->height, 0, GL_BGRA,
+				             GL_UNSIGNED_BYTE, NULL);
+
+				// Attach texture to FBO target
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i]);
+				glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER,
+				                       GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+				                       bctx->blur_texture[i], 0);
+				if (glCheckFramebufferStatus(GL_FRAMEBUFFER) !=
+				    GL_FRAMEBUFFER_COMPLETE) {
+					log_error("Framebuffer attachment failed.");
+					glBindFramebuffer(GL_FRAMEBUFFER, 0);
+					return false;
+				}
+			}
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 		} else {
 			glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[0]);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->texture_width,
-			             bctx->texture_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->fb_width,
+			             bctx->fb_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
 			glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[1]);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->texture_width,
-			             bctx->texture_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->fb_width,
+			             bctx->fb_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
 
 			// XXX: do we need projection matrix for blur at all?
 			// Note: OpenGL matrices are column major
 			GLfloat projection_matrix[4][4] = {
-			    {2.0f / (GLfloat)bctx->texture_width, 0, 0, 0},
-			    {0, 2.0f / (GLfloat)bctx->texture_height, 0, 0},
+			    {2.0f / (GLfloat)bctx->fb_width, 0, 0, 0},
+			    {0, 2.0f / (GLfloat)bctx->fb_height, 0, 0},
 			    {0, 0, 0, 0},
 			    {-1, -1, 0, 1}};
 
@@ -693,13 +856,13 @@ bool gl_blur(backend_t *base, double opacity, void *ctx, const region_t *reg_blu
 	auto coord = ccalloc(nrects * 16, GLint);
 	auto indices = ccalloc(nrects * 6, GLuint);
 	x_rect_to_coords(nrects, rects, extent_resized->x1, extent_resized->y2,
-	                 bctx->texture_height, gd->height, false, coord, indices);
+	                 bctx->fb_height, gd->height, false, coord, indices);
 
 	auto coord_resized = ccalloc(nrects_resized * 16, GLint);
 	auto indices_resized = ccalloc(nrects_resized * 6, GLuint);
 	x_rect_to_coords(nrects_resized, rects_resized, extent_resized->x1,
-	                 extent_resized->y2, bctx->texture_height, bctx->texture_height,
-	                 false, coord_resized, indices_resized);
+	                 extent_resized->y2, bctx->fb_height, bctx->fb_height, false,
+	                 coord_resized, indices_resized);
 	pixman_region32_fini(&reg_blur_resized);
 
 	GLuint vao[2];
@@ -994,10 +1157,8 @@ void gl_destroy_blur_context(backend_t *base attr_unused, void *ctx) {
 	}
 	free(bctx->blur_shader);
 
-	glDeleteTextures(bctx->npasses > 1 ? 2 : 1, bctx->blur_texture);
-	if (bctx->npasses > 1) {
-		glDeleteFramebuffers(1, &bctx->blur_fbo);
-	}
+	glDeleteTextures(bctx->blur_texture_count, bctx->blur_texture);
+	glDeleteFramebuffers(bctx->blur_fbo_count, bctx->blur_fbo);
 	free(bctx);
 
 	gl_check_err();
@@ -1126,6 +1287,10 @@ bool gl_create_kernel_blur_context(void *blur_context, enum blur_method method, 
 		ctx->npasses = nkernels;
 	}
 
+	// Specify required textures and FBOs
+	ctx->blur_texture_count = 2;
+	ctx->blur_fbo_count = 1;
+
 	success = true;
 out:
 	if (method != BLUR_METHOD_KERNEL) {
@@ -1149,11 +1314,154 @@ bool gl_create_dual_kawase_blur_context(void *blur_context, enum blur_method met
 	bool success;
 	struct gl_blur_context *ctx = blur_context;
 
-	// TODO: Create and initialize down and upsample shader
+	ctx->method = method;
 
-	log_warn("Blur method 'dual_kawase' is not yet implemented.");
-	ctx->method = BLUR_METHOD_NONE;
-	return true;
+	auto blur_params = generate_dual_kawase_params(args);
+
+	// Specify required textures and FBOs
+	ctx->blur_texture_count = blur_params->iterations;
+	ctx->blur_fbo_count = blur_params->iterations;
+
+	ctx->resize_width += blur_params->expand;
+	ctx->resize_height += blur_params->expand;
+
+	ctx->npasses = 2;
+	ctx->blur_shader = ccalloc(ctx->npasses, gl_blur_shader_t);
+
+	char *lc_numeric_old = strdup(setlocale(LC_NUMERIC, NULL));
+	// Enforce LC_NUMERIC locale "C" here to make sure decimal point is sane
+	// Thanks to hiciu for reporting.
+	setlocale(LC_NUMERIC, "C");
+
+	// Dual-kawase downsample shader / program
+	auto down_pass = ctx->blur_shader;
+	{
+		// clang-format off
+		static const char *FRAG_SHADER_DOWN = GLSL(330,
+			uniform sampler2D tex_src;
+			uniform vec2 texture_size;
+			uniform vec2 halfpixel;
+			in vec2 texcoord;
+			out vec4 out_color;
+			void main() {
+				float offset = %.7g;
+				vec2 uv = texcoord / texture_size;
+				vec4 sum = texture2D(tex_src, uv) * 4.0;
+				sum += texture2D(tex_src, uv - halfpixel.xy * offset);
+				sum += texture2D(tex_src, uv + halfpixel.xy * offset);
+				sum += texture2D(tex_src, uv + vec2(halfpixel.x, -halfpixel.y) * offset);
+				sum += texture2D(tex_src, uv - vec2(halfpixel.x, -halfpixel.y) * offset);
+				out_color = sum / 8.0;
+			}
+		);
+		// clang-format on
+
+		// Build shader
+		size_t shader_len =
+		    strlen(FRAG_SHADER_DOWN) + 10 /* offset */ + 1 /* null terminator */;
+		char *shader_str = ccalloc(shader_len, char);
+		auto real_shader_len =
+		    snprintf(shader_str, shader_len, FRAG_SHADER_DOWN, blur_params->offset);
+		CHECK(real_shader_len >= 0);
+		CHECK((size_t)real_shader_len < shader_len);
+
+		// Build program
+		down_pass->prog = gl_create_program_from_str(vertex_shader, shader_str);
+		free(shader_str);
+		if (!down_pass->prog) {
+			log_error("Failed to create GLSL program.");
+			success = false;
+			goto out;
+		}
+		glBindFragDataLocation(down_pass->prog, 0, "out_color");
+
+		// Get uniform addresses
+		down_pass->unifm_texture_size =
+		    glGetUniformLocationChecked(down_pass->prog, "texture_size");
+		down_pass->unifm_halfpixel =
+		    glGetUniformLocationChecked(down_pass->prog, "halfpixel");
+		down_pass->orig_loc =
+		    glGetUniformLocationChecked(down_pass->prog, "orig");
+		down_pass->texorig_loc =
+		    glGetUniformLocationChecked(down_pass->prog, "texorig");
+		down_pass->projection_loc =
+		    glGetUniformLocationChecked(down_pass->prog, "projection");
+	}
+
+	// Dual-kawase upsample shader / program
+	auto up_pass = ctx->blur_shader + 1;
+	{
+		// clang-format off
+		static const char *FRAG_SHADER_UP = GLSL(330,
+			uniform sampler2D tex_src;
+			uniform vec2 texture_size;
+			uniform vec2 halfpixel;
+			uniform float offset;
+			uniform float opacity;
+			in vec2 texcoord;
+			out vec4 out_color;
+			void main() {
+				float offset = %.7g;
+				vec2 uv = texcoord / texture_size;
+				vec4 sum = texture2D(tex_src, uv + vec2(-halfpixel.x * 2.0, 0.0) * offset);
+				sum += texture2D(tex_src, uv + vec2(-halfpixel.x, halfpixel.y) * offset) * 2.0;
+				sum += texture2D(tex_src, uv + vec2(0.0, halfpixel.y * 2.0) * offset);
+				sum += texture2D(tex_src, uv + vec2(halfpixel.x, halfpixel.y) * offset) * 2.0;
+				sum += texture2D(tex_src, uv + vec2(halfpixel.x * 2.0, 0.0) * offset);
+				sum += texture2D(tex_src, uv + vec2(halfpixel.x, -halfpixel.y) * offset) * 2.0;
+				sum += texture2D(tex_src, uv + vec2(0.0, -halfpixel.y * 2.0) * offset);
+				sum += texture2D(tex_src, uv + vec2(-halfpixel.x, -halfpixel.y) * offset) * 2.0;
+				out_color = sum / 12.0 * opacity;
+			}
+		);
+		// clang-format on
+
+		// Build shader
+		size_t shader_len =
+		    strlen(FRAG_SHADER_UP) + 10 /* offset */ + 1 /* null terminator */;
+		char *shader_str = ccalloc(shader_len, char);
+		auto real_shader_len =
+		    snprintf(shader_str, shader_len, FRAG_SHADER_UP, blur_params->offset);
+		CHECK(real_shader_len >= 0);
+		CHECK((size_t)real_shader_len < shader_len);
+
+		// Build program
+		up_pass->prog = gl_create_program_from_str(vertex_shader, shader_str);
+		free(shader_str);
+		if (!up_pass->prog) {
+			log_error("Failed to create GLSL program.");
+			success = false;
+			goto out;
+		}
+		glBindFragDataLocation(up_pass->prog, 0, "out_color");
+
+		// Get uniform addresses
+		up_pass->unifm_opacity =
+		    glGetUniformLocationChecked(up_pass->prog, "opacity");
+		up_pass->unifm_texture_size =
+		    glGetUniformLocationChecked(up_pass->prog, "texture_size");
+		up_pass->unifm_halfpixel =
+		    glGetUniformLocationChecked(up_pass->prog, "halfpixel");
+		up_pass->orig_loc = glGetUniformLocationChecked(up_pass->prog, "orig");
+		up_pass->texorig_loc =
+		    glGetUniformLocationChecked(up_pass->prog, "texorig");
+		up_pass->projection_loc =
+		    glGetUniformLocationChecked(up_pass->prog, "projection");
+	}
+
+	success = true;
+out:
+	free(blur_params);
+
+	if (!success) {
+		ctx = NULL;
+	}
+
+	// Restore LC_NUMERIC
+	setlocale(LC_NUMERIC, lc_numeric_old);
+	free(lc_numeric_old);
+
+	return success;
 }
 
 void *gl_create_blur_context(backend_t *base, enum blur_method method, void *args) {
@@ -1177,24 +1485,23 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 	}
 
 	// Texture size will be defined by gl_blur
-	glBindTexture(GL_TEXTURE_2D, ctx->blur_texture[0]);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-	glBindTexture(GL_TEXTURE_2D, ctx->blur_texture[1]);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glGenTextures(ctx->blur_texture_count, ctx->blur_texture);
+	for (int i = 0; i < ctx->blur_texture_count; ++i) {
+		glBindTexture(GL_TEXTURE_2D, ctx->blur_texture[i]);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
 
 	// Generate FBO and textures when needed
-	glGenFramebuffers(0, &ctx->blur_fbo);
-	if (!ctx->blur_fbo) {
-		log_error("Failed to generate framebuffer object for blur");
-		success = false;
-		goto out;
+	glGenFramebuffers(ctx->blur_fbo_count, ctx->blur_fbo);
+	for (int i = 0; i < ctx->blur_fbo_count; ++i) {
+		if (!ctx->blur_fbo[i]) {
+			log_error("Failed to generate framebuffer object for blur");
+			success = false;
+			goto out;
+		}
 	}
 
 out:

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1705,7 +1705,7 @@ static inline void gl_image_decouple(backend_t *base, struct gl_image *img) {
 	}
 
 	struct gl_data *gl = (void *)base;
-	auto new_tex = cmalloc(struct gl_texture);
+	auto new_tex = ccalloc(1, struct gl_texture);
 
 	glGenTextures(1, &new_tex->texture);
 	glBindTexture(GL_TEXTURE_2D, new_tex->texture);

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1769,7 +1769,7 @@ static void gl_image_apply_alpha(backend_t *base, struct gl_image *img,
 	glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
 	                       img->inner->texture, 0);
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
-	_gl_fill(base, (struct color){0, 0, 0, 0}, reg_op, 0, 0, false);
+	_gl_fill(base, (struct color){0, 0, 0, 0}, reg_op, fbo, 0, false);
 	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 	glDeleteFramebuffers(1, &fbo);

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -1707,14 +1707,10 @@ static inline void gl_image_decouple(backend_t *base, struct gl_image *img) {
 	struct gl_data *gl = (void *)base;
 	auto new_tex = ccalloc(1, struct gl_texture);
 
-	glGenTextures(1, &new_tex->texture);
+	new_tex->texture = gl_new_texture(GL_TEXTURE_2D);
 	glBindTexture(GL_TEXTURE_2D, new_tex->texture);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, img->inner->width, img->inner->height, 0,
 	             GL_BGRA, GL_UNSIGNED_BYTE, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 	new_tex->y_inverted = true;
 	new_tex->height = img->inner->height;
 	new_tex->width = img->inner->width;

--- a/src/backend/gl/gl_common.c
+++ b/src/backend/gl/gl_common.c
@@ -32,19 +32,17 @@ struct gl_blur_context {
 	enum blur_method method;
 	gl_blur_shader_t *blur_shader;
 
-	// TODO: allocate blur_texture and blur_fbo dynamically to allow for as many
-	// iterations as required
 	/// Temporary textures used for blurring. They are always the same size as the
 	/// target, so they are always big enough without resizing.
 	/// Turns out calling glTexImage to resize is expensive, so we avoid that.
-	GLuint blur_texture[5];
-	/// Temporary fbo used for blurring
-	GLuint blur_fbo[5];
-	/// Cached size of each `blur_texture`
-	struct {
+	GLuint *blur_textures;
+	/// Temporary fbos used for blurring
+	GLuint *blur_fbos;
+	/// Cached size of each blur_texture
+	struct texture_size {
 		int width;
 		int height;
-	} texture_size[5];
+	} * texture_sizes;
 
 	int blur_texture_count;
 	int blur_fbo_count;
@@ -560,7 +558,7 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 		const gl_blur_shader_t *p = &bctx->blur_shader[i];
 		assert(p->prog);
 
-		assert(bctx->blur_texture[curr]);
+		assert(bctx->blur_textures[curr]);
 
 		// The origin to use when sampling from the source texture
 		GLint texorig_x, texorig_y;
@@ -573,7 +571,7 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 		} else {
 			texorig_x = extent->x1 + bctx->resize_width;
 			texorig_y = dst_y_fb_coord - bctx->resize_height;
-			src_texture = bctx->blur_texture[curr];
+			src_texture = bctx->blur_textures[curr];
 		}
 
 		glBindTexture(GL_TEXTURE_2D, src_texture);
@@ -581,10 +579,10 @@ bool gl_kernel_blur(backend_t *base, double opacity, void *ctx, const rect_t *ex
 		if (i < bctx->npasses - 1) {
 			// not last pass, draw into framebuffer, with resized regions
 			glBindVertexArray(vao[1]);
-			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[0]);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[0]);
 
 			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-			                       GL_TEXTURE_2D, bctx->blur_texture[!curr], 0);
+			                       GL_TEXTURE_2D, bctx->blur_textures[!curr], 0);
 			glDrawBuffer(GL_COLOR_ATTACHMENT0);
 			if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
 				log_error("Framebuffer attachment failed.");
@@ -664,21 +662,21 @@ bool gl_dual_kawase_blur(backend_t *base, double opacity, void *ctx, const rect_
 			halfpixel_y = 0.5f / (float)gd->height;
 		} else {
 			// copy from previous pass
-			src_texture = bctx->blur_texture[i - 1];
+			src_texture = bctx->blur_textures[i - 1];
 			tex_width = bctx->fb_width;
 			tex_height = bctx->fb_height;
 
 			texorig_x = extent->x1 + bctx->resize_width;
 			texorig_y = dst_y_fb_coord - bctx->resize_height;
 
-			auto src_size = bctx->texture_size[i - 1];
+			auto src_size = bctx->texture_sizes[i - 1];
 			halfpixel_x = 0.5f / (float)src_size.width;
 			halfpixel_y = 0.5f / (float)src_size.height;
 		}
 
 		glBindTexture(GL_TEXTURE_2D, src_texture);
 		glBindVertexArray(vao[1]);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i]);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i]);
 		glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
 		glUniform2f(down_pass->texorig_loc, (GLfloat)texorig_x, (GLfloat)texorig_y);
@@ -686,7 +684,7 @@ bool gl_dual_kawase_blur(backend_t *base, double opacity, void *ctx, const rect_
 		            (GLfloat)tex_height);
 		glUniform2f(down_pass->unifm_halfpixel, halfpixel_x, halfpixel_y);
 
-		auto tgt_size = bctx->texture_size[i];
+		auto tgt_size = bctx->texture_sizes[i];
 		glViewport(0, 0, tgt_size.width, tgt_size.height);
 		glDrawElements(GL_TRIANGLES, nrects * 6, GL_UNSIGNED_INT, NULL);
 	}
@@ -705,10 +703,10 @@ bool gl_dual_kawase_blur(backend_t *base, double opacity, void *ctx, const rect_
 	            (GLfloat)bctx->fb_height);
 
 	for (int i = bctx->blur_texture_count - 1; i >= 0; --i) {
-		const GLuint src_texture = bctx->blur_texture[i];
+		const GLuint src_texture = bctx->blur_textures[i];
 		int orig_x, orig_y;
 
-		auto src_size = bctx->texture_size[i];
+		auto src_size = bctx->texture_sizes[i];
 		float halfpixel_x = 0.5f / (float)src_size.width,
 		      halfpixel_y = 0.5f / (float)src_size.height;
 
@@ -718,14 +716,14 @@ bool gl_dual_kawase_blur(backend_t *base, double opacity, void *ctx, const rect_
 		if (i > 0) {
 			// not last pass, draw into next framebuffer
 			glBindVertexArray(vao[1]);
-			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i - 1]);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i - 1]);
 			glDrawBuffer(GL_COLOR_ATTACHMENT0);
 			glClearBufferiv(GL_COLOR, 0, (GLint[4]){255, 0, 0, 255});
 
 			orig_x = bctx->resize_width;
 			orig_y = -bctx->resize_height;
 
-			auto tgt_size = bctx->texture_size[i - 1];
+			auto tgt_size = bctx->texture_sizes[i - 1];
 			vp_width = tgt_size.width;
 			vp_height = tgt_size.height;
 
@@ -777,20 +775,20 @@ bool gl_blur(backend_t *base, double opacity, void *ctx, const region_t *reg_blu
 		if (bctx->method == BLUR_METHOD_DUAL_KAWASE) {
 			// Use smaller textures for each iteration
 			for (int i = 0; i < bctx->blur_texture_count; ++i) {
-				auto tex_size = bctx->texture_size + i;
+				auto tex_size = bctx->texture_sizes + i;
 				tex_size->width = 1 + (bctx->fb_width - 1) / (1 << (i + 1));
 				tex_size->height = 1 + (bctx->fb_height - 1) / (1 << (i + 1));
 
-				glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[i]);
+				glBindTexture(GL_TEXTURE_2D, bctx->blur_textures[i]);
 				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, tex_size->width,
 				             tex_size->height, 0, GL_BGRA,
 				             GL_UNSIGNED_BYTE, NULL);
 
 				// Attach texture to FBO target
-				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbo[i]);
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, bctx->blur_fbos[i]);
 				glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER,
 				                       GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-				                       bctx->blur_texture[i], 0);
+				                       bctx->blur_textures[i], 0);
 				if (glCheckFramebufferStatus(GL_FRAMEBUFFER) !=
 				    GL_FRAMEBUFFER_COMPLETE) {
 					log_error("Framebuffer attachment failed.");
@@ -800,10 +798,10 @@ bool gl_blur(backend_t *base, double opacity, void *ctx, const region_t *reg_blu
 			}
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 		} else {
-			glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[0]);
+			glBindTexture(GL_TEXTURE_2D, bctx->blur_textures[0]);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->fb_width,
 			             bctx->fb_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
-			glBindTexture(GL_TEXTURE_2D, bctx->blur_texture[1]);
+			glBindTexture(GL_TEXTURE_2D, bctx->blur_textures[1]);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, bctx->fb_width,
 			             bctx->fb_height, 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
 
@@ -1157,8 +1155,21 @@ void gl_destroy_blur_context(backend_t *base attr_unused, void *ctx) {
 	}
 	free(bctx->blur_shader);
 
-	glDeleteTextures(bctx->blur_texture_count, bctx->blur_texture);
-	glDeleteFramebuffers(bctx->blur_fbo_count, bctx->blur_fbo);
+	if (bctx->blur_textures) {
+		glDeleteTextures(bctx->blur_texture_count, bctx->blur_textures);
+		free(bctx->blur_textures);
+	}
+	if (bctx->blur_fbos) {
+		glDeleteFramebuffers(bctx->blur_fbo_count, bctx->blur_fbos);
+		free(bctx->blur_fbos);
+	}
+	if (bctx->texture_sizes) {
+		free(bctx->texture_sizes);
+	}
+
+	bctx->blur_texture_count = 0;
+	bctx->blur_fbo_count = 0;
+
 	free(bctx);
 
 	gl_check_err();
@@ -1485,9 +1496,11 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 	}
 
 	// Texture size will be defined by gl_blur
-	glGenTextures(ctx->blur_texture_count, ctx->blur_texture);
+	ctx->blur_textures = ccalloc(ctx->blur_texture_count, GLuint);
+	ctx->texture_sizes = ccalloc(ctx->blur_texture_count, struct texture_size);
+	glGenTextures(ctx->blur_texture_count, ctx->blur_textures);
 	for (int i = 0; i < ctx->blur_texture_count; ++i) {
-		glBindTexture(GL_TEXTURE_2D, ctx->blur_texture[i]);
+		glBindTexture(GL_TEXTURE_2D, ctx->blur_textures[i]);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -1495,9 +1508,10 @@ void *gl_create_blur_context(backend_t *base, enum blur_method method, void *arg
 	}
 
 	// Generate FBO and textures when needed
-	glGenFramebuffers(ctx->blur_fbo_count, ctx->blur_fbo);
+	ctx->blur_fbos = ccalloc(ctx->blur_fbo_count, GLuint);
+	glGenFramebuffers(ctx->blur_fbo_count, ctx->blur_fbos);
 	for (int i = 0; i < ctx->blur_fbo_count; ++i) {
-		if (!ctx->blur_fbo[i]) {
+		if (!ctx->blur_fbos[i]) {
 			log_error("Failed to generate framebuffer object for blur");
 			success = false;
 			goto out;

--- a/src/backend/gl/gl_common.h
+++ b/src/backend/gl/gl_common.h
@@ -33,8 +33,11 @@ typedef struct {
 typedef struct {
 	GLuint prog;
 	GLint unifm_opacity;
+	GLint unifm_texture_size;
+	GLint unifm_halfpixel;
 	GLint orig_loc;
 	GLint texorig_loc;
+	GLint projection_loc;
 } gl_blur_shader_t;
 
 typedef struct {
@@ -168,7 +171,8 @@ static inline void gl_check_err_(const char *func, int line) {
 }
 
 static inline void gl_clear_err(void) {
-	while (glGetError() != GL_NO_ERROR);
+	while (glGetError() != GL_NO_ERROR)
+		;
 }
 
 #define gl_check_err() gl_check_err_(__func__, __LINE__)

--- a/src/backend/xrender/xrender.c
+++ b/src/backend/xrender/xrender.c
@@ -505,6 +505,12 @@ void *create_blur_context(backend_t *base attr_unused, enum blur_method method, 
 		ret->method = BLUR_METHOD_NONE;
 		return ret;
 	}
+	if (method == BLUR_METHOD_DUAL_KAWASE) {
+		log_warn("Blur method 'dual_kawase' is not compatible with the 'xrender' "
+		         "backend.");
+		ret->method = BLUR_METHOD_NONE;
+		return ret;
+	}
 
 	ret->method = BLUR_METHOD_KERNEL;
 	struct conv **kernels;

--- a/src/c2.c
+++ b/src/c2.c
@@ -1328,7 +1328,7 @@ static inline void c2_match_once_leaf(session_t *ps, const struct managed_win *w
 			case C2_L_PFULLSCREEN: tgt = win_is_fullscreen(ps, w); break;
 			case C2_L_POVREDIR: tgt = w->a.override_redirect; break;
 			case C2_L_PARGB: tgt = win_has_alpha(w); break;
-			case C2_L_PFOCUSED: tgt = win_is_focused_real(ps, w); break;
+			case C2_L_PFOCUSED: tgt = win_is_focused_raw(ps, w); break;
 			case C2_L_PWMWIN: tgt = w->wmwin; break;
 			case C2_L_PBSHAPED: tgt = w->bounding_shaped; break;
 			case C2_L_PROUNDED: tgt = w->rounded_corners; break;

--- a/src/common.h
+++ b/src/common.h
@@ -107,10 +107,15 @@ typedef struct glx_prog_main {
 	GLint unifm_invert_color;
 	/// Location of uniform "tex" in window GLSL program.
 	GLint unifm_tex;
+	/// Location of uniform "time" in window GLSL program.
+	GLint unifm_time;
 } glx_prog_main_t;
 
 #define GLX_PROG_MAIN_INIT                                                               \
-	{ .prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1, .unifm_tex = -1, }
+	{                                                                                \
+		.prog = 0, .unifm_opacity = -1, .unifm_invert_color = -1,                \
+		.unifm_tex = -1, .unifm_time = -1                                        \
+	}
 
 #else
 struct glx_prog_main {};

--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,8 @@ enum blur_method parse_blur_method(const char *src) {
 		return BLUR_METHOD_BOX;
 	} else if (strcmp(src, "gaussian") == 0) {
 		return BLUR_METHOD_GAUSSIAN;
+	} else if (strcmp(src, "dual_kawase") == 0) {
+		return BLUR_METHOD_DUAL_KAWASE;
 	} else if (strcmp(src, "none") == 0) {
 		return BLUR_METHOD_NONE;
 	}
@@ -542,6 +544,7 @@ char *parse_config(options_t *opt, const char *config_file, bool *shadow_enable,
 	    .blur_method = BLUR_METHOD_NONE,
 	    .blur_radius = -1,
 	    .blur_deviation = 0.84089642,
+	    .blur_strength = -1,
 	    .blur_background_frame = false,
 	    .blur_background_fixed = false,
 	    .blur_background_blacklist = NULL,

--- a/src/config.h
+++ b/src/config.h
@@ -60,6 +60,7 @@ enum blur_method {
 	BLUR_METHOD_KERNEL,
 	BLUR_METHOD_BOX,
 	BLUR_METHOD_GAUSSIAN,
+	BLUR_METHOD_DUAL_KAWASE,
 	BLUR_METHOD_INVALID,
 };
 
@@ -189,6 +190,8 @@ typedef struct options {
 	int blur_radius;
 	// Standard deviation for the gaussian blur
 	double blur_deviation;
+	// Strength of the dual_kawase blur
+	int blur_strength;
 	/// Whether to blur background when the window frame is not opaque.
 	/// Implies blur_background.
 	bool blur_background_frame;

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -394,6 +394,8 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 	config_lookup_int(&cfg, "blur-size", &opt->blur_radius);
 	// --blur-deviation
 	config_lookup_float(&cfg, "blur-deviation", &opt->blur_deviation);
+	// --blur-strength
+	config_lookup_int(&cfg, "blur-strength", &opt->blur_strength);
 	// --blur-background
 	if (config_lookup_bool(&cfg, "blur-background", &ival) && ival) {
 		if (opt->blur_method == BLUR_METHOD_NONE) {
@@ -507,6 +509,7 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 		}
 
 		config_setting_lookup_float(blur_cfg, "deviation", &opt->blur_deviation);
+		config_setting_lookup_int(blur_cfg, "strength", &opt->blur_strength);
 	}
 
 	// Wintype settings

--- a/src/config_libconfig.c
+++ b/src/config_libconfig.c
@@ -499,6 +499,11 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 		}
 
 		config_setting_lookup_int(blur_cfg, "size", &opt->blur_radius);
+		if (opt->blur_method == BLUR_METHOD_DUAL_KAWASE && opt->blur_radius > 500) {
+			log_warn("Blur radius >500 not supported by dual_kawase method, "
+			         "capping to 500.");
+			opt->blur_radius = 500;
+		}
 
 		if (config_setting_lookup_string(blur_cfg, "kernel", &sval)) {
 			opt->blur_kerns = parse_blur_kern_lst(sval, conv_kern_hasneg,
@@ -510,6 +515,11 @@ char *parse_config_libconfig(options_t *opt, const char *config_file, bool *shad
 
 		config_setting_lookup_float(blur_cfg, "deviation", &opt->blur_deviation);
 		config_setting_lookup_int(blur_cfg, "strength", &opt->blur_strength);
+		if (opt->blur_method == BLUR_METHOD_DUAL_KAWASE && opt->blur_strength > 20) {
+			log_warn("Blur strength >20 not supported by dual_kawase method, "
+			         "capping to 20.");
+			opt->blur_strength = 20;
+		}
 	}
 
 	// Wintype settings

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -785,9 +785,8 @@ static bool cdbus_process_win_get(session_t *ps, DBusMessage *msg) {
 	cdbus_m_win_get_do(window_type, cdbus_reply_enum);
 	cdbus_m_win_get_do(wmwin, cdbus_reply_bool);
 	cdbus_m_win_get_do(leader, cdbus_reply_wid);
-	// focused_real
-	if (!strcmp("focused_real", target)) {
-		cdbus_reply_bool(ps, msg, win_is_focused_real(ps, w));
+	if (!strcmp("focused_raw", target)) {
+		cdbus_reply_bool(ps, msg, win_is_focused_raw(ps, w));
 		return true;
 	}
 	cdbus_m_win_get_do(fade_force, cdbus_reply_enum);

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -3,13 +3,15 @@
 
 #include <stdio.h>
 #include <xcb/xcb.h>
+#include <xcb/composite.h>
 
 #include "backend/driver.h"
 #include "diagnostic.h"
 #include "config.h"
+#include "picom.h"
 #include "common.h"
 
-void print_diagnostics(session_t *ps, const char *config_file) {
+void print_diagnostics(session_t *ps, const char *config_file, bool compositor_running) {
 	printf("**Version:** " COMPTON_VERSION "\n");
 	//printf("**CFLAGS:** %s\n", "??");
 	printf("\n### Extensions:\n\n");
@@ -17,7 +19,16 @@ void print_diagnostics(session_t *ps, const char *config_file) {
 	printf("* XRandR: %s\n", ps->randr_exists ? "Yes" : "No");
 	printf("* Present: %s\n", ps->present_exists ? "Present" : "Not Present");
 	printf("\n### Misc:\n\n");
-	printf("* Use Overlay: %s\n", ps->overlay != XCB_NONE ? "Yes" : "No");
+	printf("* Use Overlay: %s", ps->overlay != XCB_NONE ? "Yes" : "No");
+	if (ps->overlay == XCB_NONE) {
+		if (compositor_running) {
+			printf(" (Another compositor is already running)\n");
+		} else if (session_redirection_mode(ps) != XCB_COMPOSITE_REDIRECT_MANUAL) {
+			printf(" (Not in manual redirection mode)\n");
+		} else {
+			printf("\n");
+		}
+	}
 #ifdef __FAST_MATH__
 	printf("* Fast Math: Yes\n");
 #endif

--- a/src/diagnostic.h
+++ b/src/diagnostic.h
@@ -2,7 +2,8 @@
 // Copyright (c) 2018 Yuxuan Shui <yshuiv7@gmail.com>
 
 #pragma once
+#include <stdbool.h>
 
 typedef struct session session_t;
 
-void print_diagnostics(session_t *, const char *config_file);
+void print_diagnostics(session_t *, const char *config_file, bool compositor_running);

--- a/src/opengl.c
+++ b/src/opengl.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <xcb/render.h>
 #include <xcb/xcb.h>
 
@@ -442,6 +443,7 @@ bool glx_load_prog_main(const char *vshader_str, const char *fshader_str,
 	P_GET_UNIFM_LOC("opacity", unifm_opacity);
 	P_GET_UNIFM_LOC("invert_color", unifm_invert_color);
 	P_GET_UNIFM_LOC("tex", unifm_tex);
+	P_GET_UNIFM_LOC("time", unifm_time);
 #undef P_GET_UNIFM_LOC
 
 	gl_check_err();
@@ -1029,12 +1031,16 @@ bool glx_render(session_t *ps, const glx_texture_t *ptex, int x, int y, int dx, 
 		// Programmable path
 		assert(pprogram->prog);
 		glUseProgram(pprogram->prog);
+		struct timespec ts;
+		clock_gettime(CLOCK_MONOTONIC, &ts);
 		if (pprogram->unifm_opacity >= 0)
 			glUniform1f(pprogram->unifm_opacity, (float)opacity);
 		if (pprogram->unifm_invert_color >= 0)
 			glUniform1i(pprogram->unifm_invert_color, neg);
 		if (pprogram->unifm_tex >= 0)
 			glUniform1i(pprogram->unifm_tex, 0);
+		if (pprogram->unifm_time >= 0)
+			glUniform1f(pprogram->unifm_time, (float)ts.tv_sec * 1000.0f + (float)ts.tv_nsec / 1.0e6f);
 	}
 
 	// log_trace("Draw: %d, %d, %d, %d -> %d, %d (%d, %d) z %d", x, y, width, height,

--- a/src/options.c
+++ b/src/options.c
@@ -212,6 +212,9 @@ static void usage(const char *argv0, int ret) {
 	    "--blur-deviation\n"
 	    "  The standard deviation for the 'gaussian' blur method.\n"
 	    "\n"
+	    "--blur-strength\n"
+	    "  The strength level of the 'dual_kawase' blur method.\n"
+	    "\n"
 	    "--blur-background\n"
 	    "  Blur background of semi-transparent / ARGB windows. Bad in\n"
 	    "  performance. The switch name may change without prior\n"
@@ -437,6 +440,7 @@ static const struct option longopts[] = {
     {"blur-method", required_argument, NULL, 328},
     {"blur-size", required_argument, NULL, 329},
     {"blur-deviation", required_argument, NULL, 330},
+    {"blur-strength", required_argument, NULL, 331},
     {"experimental-backends", no_argument, NULL, 733},
     {"monitor-repaint", no_argument, NULL, 800},
     {"diagnostics", no_argument, NULL, 801},
@@ -841,6 +845,10 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			// --blur-deviation
 			opt->blur_deviation = atof(optarg);
 			break;
+		case 331:
+			// --blur-strength
+			opt->blur_strength = atoi(optarg);
+			break;
 
 		P_CASEBOOL(733, experimental_backends);
 		P_CASEBOOL(800, monitor_repaint);
@@ -928,6 +936,20 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 		                                      &opt->blur_kernel_count);
 		CHECK(opt->blur_kerns);
 		CHECK(opt->blur_kernel_count);
+	}
+
+	// Sanitize parameters for dual-filter kawase blur
+	if (opt->blur_method == BLUR_METHOD_DUAL_KAWASE) {
+		if (opt->blur_strength < 0 && opt->blur_radius > 500) {
+			log_warn("Blur radius >500 not supported by dual_kawase method, "
+			         "capping to 500.");
+			opt->blur_radius = 500;
+		}
+		if (opt->blur_strength > 20) {
+			log_warn("Blur strength >20 not supported by dual_kawase method, "
+			         "capping to 20.");
+			opt->blur_strength = 20;
+		}
 	}
 
 	if (opt->resize_damage < 0) {

--- a/src/picom.c
+++ b/src/picom.c
@@ -936,9 +936,11 @@ void opts_set_no_fading_openclose(session_t *ps, bool newval) {
 #endif
 
 /**
- * Register a window as symbol, and initialize GLX context if wanted.
+ * Register us with the compositor selection (_NET_WM_CM_S)
+ *
+ * @return 0 if success, 1 if compositor already running, -1 if error.
  */
-static bool register_cm(session_t *ps) {
+static int register_cm(session_t *ps) {
 	assert(!ps->reg_win);
 
 	ps->reg_win = x_new_id(ps->c);
@@ -949,7 +951,7 @@ static bool register_cm(session_t *ps) {
 	if (e) {
 		log_fatal("Failed to create window.");
 		free(e);
-		return false;
+		return -1;
 	}
 
 	{
@@ -984,7 +986,7 @@ static bool register_cm(session_t *ps) {
 		char *buf = NULL;
 		if (asprintf(&buf, "%s%d", register_prop, ps->scr) < 0) {
 			log_fatal("Failed to allocate memory");
-			return false;
+			return -1;
 		}
 		atom = get_atom(ps->atoms, buf);
 		free(buf);
@@ -993,15 +995,15 @@ static bool register_cm(session_t *ps) {
 		    ps->c, xcb_get_selection_owner(ps->c, atom), NULL);
 
 		if (reply && reply->owner != XCB_NONE) {
+			// Another compositor already running
 			free(reply);
-			log_fatal("Another composite manager is already running");
-			return false;
+			return 1;
 		}
 		free(reply);
 		xcb_set_selection_owner(ps->c, ps->reg_win, atom, 0);
 	}
 
-	return true;
+	return 0;
 }
 
 /**
@@ -1181,7 +1183,7 @@ xcb_window_t session_get_target_window(session_t *ps) {
 	return ps->overlay != XCB_NONE ? ps->overlay : ps->root;
 }
 
-static inline uint8_t session_redirection_mode(session_t *ps) {
+uint8_t session_redirection_mode(session_t *ps) {
 	if (ps->o.debug_mode) {
 		// If the backend is not rendering to the screen, we don't need to
 		// take over the screen.
@@ -1926,27 +1928,61 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 
 	rebuild_screen_reg(ps);
 
-	// Create registration window
-	// If we are not taking over the screen, we don't need to register as a compositor
-	if (session_redirection_mode(ps) == XCB_COMPOSITE_REDIRECT_MANUAL && !register_cm(ps)) {
-		exit(1);
+	bool compositor_running = false;
+	if (session_redirection_mode(ps) == XCB_COMPOSITE_REDIRECT_MANUAL) {
+		// We are running in the manual redirection mode, meaning we are running
+		// as a proper compositor. So we need to register us as a compositor, etc.
+
+		// We are also here when --diagnostics is set. We want to be here because
+		// that gives us more diagnostic information.
+
+		// Create registration window
+		int ret = register_cm(ps);
+		if (ret == -1) {
+			exit(1);
+		}
+
+		compositor_running = ret == 1;
+		if (compositor_running) {
+			// Don't take the overlay when there is another compositor
+			// running, so we don't disrupt it.
+
+			// If we are printing diagnostic, we will continue a bit further
+			// to get more diagnostic information, otherwise we will exit.
+			if (!ps->o.print_diagnostics) {
+				log_fatal("Another composite manager is already running");
+				exit(1);
+			}
+		} else {
+			if (!init_overlay(ps)) {
+				goto err;
+			}
+		}
+	} else {
+		// We are here if we don't really function as a compositor, so we are not
+		// taking over the screen, and we don't need to register as a compositor
+
+		// If we are in debug mode, we need to create a window for rendering if
+		// the backend supports presenting.
+
+		// The old backends doesn't have a automatic redirection mode
+		log_info("The compositor is started in automatic redirection mode.");
+		assert(ps->o.experimental_backends);
+
+		if (backend_list[ps->o.backend]->present) {
+			// If the backend has `present`, we couldn't be in automatic
+			// redirection mode unless we are in debug mode.
+			assert(ps->o.debug_mode);
+			if (!init_debug_window(ps)) {
+				goto err;
+			}
+		}
 	}
 
 	// Target window must be initialized before the backend
 	//
 	// backend_operations::present == NULL means this backend doesn't need a target
 	// window; non experimental backends always need a target window
-	if (!ps->o.experimental_backends || backend_list[ps->o.backend]->present != NULL) {
-		if (!ps->o.debug_mode) {
-			if (!init_overlay(ps)) {
-				goto err;
-			}
-		} else {
-			if (!init_debug_window(ps)) {
-				goto err;
-			}
-		}
-	}
 
 	ps->drivers = detect_driver(ps->c, ps->backend_data, ps->root);
 
@@ -1957,7 +1993,7 @@ static session_t *session_init(int argc, char **argv, Display *dpy,
 	}
 
 	if (ps->o.print_diagnostics) {
-		print_diagnostics(ps, config_file);
+		print_diagnostics(ps, config_file, compositor_running);
 		free(config_file_to_free);
 		exit(0);
 	}

--- a/src/picom.c
+++ b/src/picom.c
@@ -500,11 +500,6 @@ static struct managed_win *paint_preprocess(session_t *ps, bool *fade_running) {
 			rc_region_unref(&w->reg_ignore);
 		}
 
-		// Clear flags if we are not using experimental backends
-		if (!ps->o.experimental_backends) {
-			w->flags = 0;
-		}
-
 		// log_trace("%d %d %s", w->a.map_state, w->ever_damaged, w->name);
 
 		// Give up if it's not damaged or invisible, or it's unmapped and its

--- a/src/picom.c
+++ b/src/picom.c
@@ -709,6 +709,7 @@ static bool initialize_blur(session_t *ps) {
 	struct kernel_blur_args kargs;
 	struct gaussian_blur_args gargs;
 	struct box_blur_args bargs;
+	struct dual_kawase_blur_args dkargs;
 
 	void *args = NULL;
 	switch (ps->o.blur_method) {
@@ -725,6 +726,11 @@ static bool initialize_blur(session_t *ps) {
 		gargs.size = ps->o.blur_radius;
 		gargs.deviation = ps->o.blur_deviation;
 		args = (void *)&gargs;
+		break;
+	case BLUR_METHOD_DUAL_KAWASE:
+		dkargs.size = ps->o.blur_radius;
+		dkargs.strength = ps->o.blur_strength;
+		args = (void *)&dkargs;
 		break;
 	default: return true;
 	}

--- a/src/picom.h
+++ b/src/picom.h
@@ -61,6 +61,8 @@ void quit(session_t *ps);
 
 xcb_window_t session_get_target_window(session_t *);
 
+uint8_t session_redirection_mode(session_t *ps);
+
 /**
  * Set a <code>switch_t</code> array of all unset wintypes to true.
  */

--- a/src/win.c
+++ b/src/win.c
@@ -906,36 +906,19 @@ void win_update_opacity_rule(session_t *ps, struct managed_win *w) {
 }
 
 /**
- * Function to be called on window type changes.
- */
-static void win_on_wtype_change(session_t *ps, struct managed_win *w) {
-	win_determine_shadow(ps, w);
-	win_update_focused(ps, w);
-	if (ps->o.invert_color_list)
-		win_determine_invert_color(ps, w);
-	if (ps->o.opacity_rules)
-		win_update_opacity_rule(ps, w);
-}
-
-/**
  * Function to be called on window data changes.
  *
  * TODO need better name
  */
 void win_on_factor_change(session_t *ps, struct managed_win *w) {
-	if (ps->o.shadow_blacklist)
-		win_determine_shadow(ps, w);
-	if (ps->o.invert_color_list)
-		win_determine_invert_color(ps, w);
-	if (ps->o.focus_blacklist)
-		win_update_focused(ps, w);
-	if (ps->o.blur_background_blacklist)
-		win_determine_blur_background(ps, w);
-	if (ps->o.opacity_rules)
-		win_update_opacity_rule(ps, w);
-	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE && ps->o.paint_blacklist)
+	win_determine_shadow(ps, w);
+	win_determine_invert_color(ps, w);
+	win_update_focused(ps, w);
+	win_determine_blur_background(ps, w);
+	win_update_opacity_rule(ps, w);
+	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE)
 		w->paint_excluded = c2_match(ps, w, ps->o.paint_blacklist, NULL);
-	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE && ps->o.unredir_if_possible_blacklist)
+	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE)
 		w->unredir_if_possible_excluded =
 		    c2_match(ps, w, ps->o.unredir_if_possible_blacklist, NULL);
 	w->reg_ignore_valid = false;
@@ -984,7 +967,7 @@ void win_update_wintype(session_t *ps, struct managed_win *w) {
 	}
 
 	if (w->window_type != wtype_old)
-		win_on_wtype_change(ps, w);
+		win_on_factor_change(ps, w);
 }
 
 /**

--- a/src/win.c
+++ b/src/win.c
@@ -211,24 +211,26 @@ void win_get_region_noframe_local(const struct managed_win *w, region_t *res) {
 
 void win_get_region_frame_local(const struct managed_win *w, region_t *res) {
 	const margin_t extents = win_calc_frame_extents(w);
+	auto outer_width = extents.left + extents.right + w->g.width;
+	auto outer_height = extents.top + extents.bottom + w->g.height;
 	pixman_region32_fini(res);
 	pixman_region32_init_rects(
 	    res,
 	    (rect_t[]){
 	        // top
-	        {.x1 = 0, .y1 = 0, .x2 = w->g.width, .y2 = extents.top},
+	        {.x1 = 0, .y1 = 0, .x2 = outer_width, .y2 = extents.top},
 	        // bottom
-	        {.x1 = 0, .y1 = w->g.height - extents.bottom, .x2 = w->g.width, .y2 = w->g.height},
+	        {.x1 = 0, .y1 = outer_height - extents.bottom, .x2 = outer_width, .y2 = outer_height},
 	        // left
-	        {.x1 = 0, .y1 = 0, .x2 = extents.left, .y2 = w->g.height},
+	        {.x1 = 0, .y1 = 0, .x2 = extents.left, .y2 = outer_height},
 	        // right
-	        {.x1 = w->g.width - extents.right, .y1 = 0, .x2 = w->g.width, .y2 = w->g.height},
+	        {.x1 = outer_width - extents.right, .y1 = 0, .x2 = outer_width, .y2 = outer_height},
 	    },
 	    4);
 
 	// limit the frame region to inside the window
 	region_t reg_win;
-	pixman_region32_init_rect(&reg_win, 0, 0, w->g.width, w->g.height);
+	pixman_region32_init_rects(&reg_win, (rect_t[]){0, 0, outer_width, outer_height}, 1);
 	pixman_region32_intersect(res, &reg_win, res);
 	pixman_region32_fini(&reg_win);
 }

--- a/src/win.c
+++ b/src/win.c
@@ -728,13 +728,15 @@ static void win_set_shadow(session_t *ps, struct managed_win *w, bool shadow_new
 	// asserting the existence of the shadow image.
 	if (w->shadow) {
 		// Mark the new extents as damaged if the shadow is added
-		assert(!w->shadow_image || (w->flags & WIN_FLAGS_SHADOW_STALE));
+		assert(!w->shadow_image || (w->flags & WIN_FLAGS_SHADOW_STALE) ||
+		       !ps->o.experimental_backends);
 		pixman_region32_clear(&extents);
 		win_extents(w, &extents);
 		add_damage_from_win(ps, w);
 	} else {
 		// Mark the old extents as damaged if the shadow is removed
-		assert(w->shadow_image || (w->flags & WIN_FLAGS_SHADOW_STALE));
+		assert(w->shadow_image || (w->flags & WIN_FLAGS_SHADOW_STALE) ||
+		       !ps->o.experimental_backends);
 		add_damage(ps, &extents);
 	}
 

--- a/src/win.c
+++ b/src/win.c
@@ -112,27 +112,14 @@ static void win_update_focused(session_t *ps, struct managed_win *w) {
 			w->focused = true;
 		}
 	}
-
-	// Always recalculate the window target opacity, since some opacity-related
-	// options depend on the output value of win_is_focused_raw() instead of
-	// w->focused
-	auto opacity_target_old = w->opacity_target;
-	w->opacity_target = win_calc_opacity_target(ps, w, false);
-	if (opacity_target_old != w->opacity_target && w->state == WSTATE_MAPPED) {
-		// Only MAPPED can transition to FADING
-		w->state = WSTATE_FADING;
-		if (!ps->redirected) {
-			CHECK(!win_skip_fading(ps, w));
-		}
-	}
 }
 
 /**
- * Run win_update_focused() on all windows with the same leader window.
+ * Run win_on_factor_change() on all windows with the same leader window.
  *
  * @param leader leader window ID
  */
-static inline void group_update_focused(session_t *ps, xcb_window_t leader) {
+static inline void group_on_factor_change(session_t *ps, xcb_window_t leader) {
 	if (!leader)
 		return;
 
@@ -143,7 +130,7 @@ static inline void group_update_focused(session_t *ps, xcb_window_t leader) {
 		}
 		auto mw = (struct managed_win *)w;
 		if (win_get_leader(ps, mw) == leader) {
-			win_update_focused(ps, mw);
+			win_on_factor_change(ps, mw);
 		}
 	}
 
@@ -844,7 +831,7 @@ void win_set_fade_force(struct managed_win *w, switch_t val) {
 void win_set_focused_force(session_t *ps, struct managed_win *w, switch_t val) {
 	if (val != w->focused_force) {
 		w->focused_force = val;
-		win_update_focused(ps, w);
+		win_on_factor_change(ps, w);
 		queue_redraw(ps);
 	}
 }
@@ -911,9 +898,12 @@ void win_update_opacity_rule(session_t *ps, struct managed_win *w) {
  * TODO need better name
  */
 void win_on_factor_change(session_t *ps, struct managed_win *w) {
+	// Focus needs to be updated first, as other rules might depend on the focused
+	// state of the window
+	win_update_focused(ps, w);
+
 	win_determine_shadow(ps, w);
 	win_determine_invert_color(ps, w);
-	win_update_focused(ps, w);
 	win_determine_blur_background(ps, w);
 	win_update_opacity_rule(ps, w);
 	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE)
@@ -921,6 +911,17 @@ void win_on_factor_change(session_t *ps, struct managed_win *w) {
 	if (w->a.map_state == XCB_MAP_STATE_VIEWABLE)
 		w->unredir_if_possible_excluded =
 		    c2_match(ps, w, ps->o.unredir_if_possible_blacklist, NULL);
+
+	auto opacity_target_old = w->opacity_target;
+	w->opacity_target = win_calc_opacity_target(ps, w, false);
+	if (opacity_target_old != w->opacity_target && w->state == WSTATE_MAPPED) {
+		// Only MAPPED can transition to FADING
+		w->state = WSTATE_FADING;
+		if (!ps->redirected) {
+			CHECK(!win_skip_fading(ps, w));
+		}
+	}
+
 	w->reg_ignore_valid = false;
 }
 
@@ -1013,9 +1014,6 @@ void win_mark_client(session_t *ps, struct managed_win *w, xcb_window_t client) 
 
 	// Update everything related to conditions
 	win_on_factor_change(ps, w);
-
-	// Update window focus state
-	win_update_focused(ps, w);
 
 	auto r = xcb_get_window_attributes_reply(
 	    ps->c, xcb_get_window_attributes(ps->c, w->client_win), NULL);
@@ -1333,12 +1331,8 @@ static inline void win_set_leader(session_t *ps, struct managed_win *w, xcb_wind
 		if (win_is_focused_raw(ps, w) && cache_leader_old != cache_leader) {
 			ps->active_leader = cache_leader;
 
-			group_update_focused(ps, cache_leader_old);
-			group_update_focused(ps, cache_leader);
-		}
-		// Otherwise, at most the window itself is affected
-		else {
-			win_update_focused(ps, w);
+			group_on_factor_change(ps, cache_leader_old);
+			group_on_factor_change(ps, cache_leader);
 		}
 
 		// Update everything related to conditions
@@ -1442,22 +1436,15 @@ static void win_on_focus_change(session_t *ps, struct managed_win *w) {
 
 			ps->active_leader = leader;
 
-			group_update_focused(ps, active_leader_old);
-			group_update_focused(ps, leader);
+			group_on_factor_change(ps, active_leader_old);
+			group_on_factor_change(ps, leader);
 		}
 		// If the group get unfocused, remove it from active_leader
 		else if (!win_is_focused_raw(ps, w) && leader &&
 		         leader == ps->active_leader && !group_is_focused(ps, leader)) {
 			ps->active_leader = XCB_NONE;
-			group_update_focused(ps, leader);
+			group_on_factor_change(ps, leader);
 		}
-
-		// The window itself must be updated anyway
-		win_update_focused(ps, w);
-	}
-	// Otherwise, only update the window itself
-	else {
-		win_update_focused(ps, w);
 	}
 
 	// Update everything related to conditions
@@ -2090,6 +2077,8 @@ void map_win_start(session_t *ps, struct managed_win *w) {
 	assert(w->client_win);
 
 	log_debug("Window (%#010x) has type %s", w->base.id, WINTYPES[w->window_type]);
+
+	// TODO can we just replace calls below with win_on_factor_change?
 
 	// Update window focus state
 	win_update_focused(ps, w);

--- a/src/win.c
+++ b/src/win.c
@@ -94,7 +94,7 @@ static void win_update_focused(session_t *ps, struct managed_win *w) {
 	if (UNSET != w->focused_force) {
 		w->focused = w->focused_force;
 	} else {
-		w->focused = win_is_focused_real(ps, w);
+		w->focused = win_is_focused_raw(ps, w);
 
 		// Use wintype_focus, and treat WM windows and override-redirected
 		// windows specially
@@ -114,7 +114,7 @@ static void win_update_focused(session_t *ps, struct managed_win *w) {
 	}
 
 	// Always recalculate the window target opacity, since some opacity-related
-	// options depend on the output value of win_is_focused_real() instead of
+	// options depend on the output value of win_is_focused_raw() instead of
 	// w->focused
 	auto opacity_target_old = w->opacity_target;
 	w->opacity_target = win_calc_opacity_target(ps, w, false);
@@ -175,7 +175,7 @@ static inline bool group_is_focused(session_t *ps, xcb_window_t leader) {
 			continue;
 		}
 		auto mw = (struct managed_win *)w;
-		if (win_get_leader(ps, mw) == leader && win_is_focused_real(ps, mw)) {
+		if (win_get_leader(ps, mw) == leader && win_is_focused_raw(ps, mw)) {
 			return true;
 		}
 	}
@@ -615,7 +615,7 @@ double win_calc_opacity_target(session_t *ps, const struct managed_win *w, bool 
 		opacity = ps->o.wintype_option[w->window_type].opacity;
 	} else {
 		// Respect active_opacity only when the window is physically focused
-		if (win_is_focused_real(ps, w))
+		if (win_is_focused_raw(ps, w))
 			opacity = ps->o.active_opacity;
 		else if (!w->focused)
 			// Respect inactive_opacity in some cases
@@ -1347,7 +1347,7 @@ static inline void win_set_leader(session_t *ps, struct managed_win *w, xcb_wind
 		// Update the old and new window group and active_leader if the window
 		// could affect their state.
 		xcb_window_t cache_leader = win_get_leader(ps, w);
-		if (win_is_focused_real(ps, w) && cache_leader_old != cache_leader) {
+		if (win_is_focused_raw(ps, w) && cache_leader_old != cache_leader) {
 			ps->active_leader = cache_leader;
 
 			group_update_focused(ps, cache_leader_old);
@@ -1454,7 +1454,7 @@ static void win_on_focus_change(session_t *ps, struct managed_win *w) {
 		xcb_window_t leader = win_get_leader(ps, w);
 
 		// If the window gets focused, replace the old active_leader
-		if (win_is_focused_real(ps, w) && leader != ps->active_leader) {
+		if (win_is_focused_raw(ps, w) && leader != ps->active_leader) {
 			xcb_window_t active_leader_old = ps->active_leader;
 
 			ps->active_leader = leader;
@@ -1463,7 +1463,7 @@ static void win_on_focus_change(session_t *ps, struct managed_win *w) {
 			group_update_focused(ps, leader);
 		}
 		// If the group get unfocused, remove it from active_leader
-		else if (!win_is_focused_real(ps, w) && leader &&
+		else if (!win_is_focused_raw(ps, w) && leader &&
 		         leader == ps->active_leader && !group_is_focused(ps, leader)) {
 			ps->active_leader = XCB_NONE;
 			group_update_focused(ps, leader);
@@ -1483,7 +1483,7 @@ static void win_on_focus_change(session_t *ps, struct managed_win *w) {
 #ifdef CONFIG_DBUS
 	// Send D-Bus signal
 	if (ps->o.dbus) {
-		if (win_is_focused_real(ps, w))
+		if (win_is_focused_raw(ps, w))
 			cdbus_ev_win_focusin(ps, &w->base);
 		else
 			cdbus_ev_win_focusout(ps, &w->base);
@@ -1500,13 +1500,13 @@ void win_set_focused(session_t *ps, struct managed_win *w) {
 		return;
 	}
 
-	if (win_is_focused_real(ps, w)) {
+	if (win_is_focused_raw(ps, w)) {
 		return;
 	}
 
 	auto old_active_win = ps->active_win;
 	ps->active_win = w;
-	assert(win_is_focused_real(ps, w));
+	assert(win_is_focused_raw(ps, w));
 
 	if (old_active_win) {
 		win_on_focus_change(ps, old_active_win);
@@ -2339,9 +2339,9 @@ bool win_is_bypassing_compositor(const session_t *ps, const struct managed_win *
 }
 
 /**
- * Check if a window is really focused.
+ * Check if a window is focused, without using any focus rules or forced focus settings
  */
-bool win_is_focused_real(const session_t *ps, const struct managed_win *w) {
+bool win_is_focused_raw(const session_t *ps, const struct managed_win *w) {
 	return w->a.map_state == XCB_MAP_STATE_VIEWABLE && ps->active_win == w;
 }
 

--- a/src/win.c
+++ b/src/win.c
@@ -550,9 +550,6 @@ winmode_t win_calc_mode(const struct managed_win *w) {
 	if (w->opacity < 1.0) {
 		return WMODE_TRANS;
 	}
-	if (w->frame_opacity != 1.0 && win_has_frame(w)) {
-		return WMODE_FRAME_TRANS;
-	}
 
 	if (win_has_alpha(w)) {
 		if (w->client_win == XCB_NONE) {
@@ -573,6 +570,10 @@ winmode_t win_calc_mode(const struct managed_win *w) {
 		}
 		// Although the WM window has alpha, the frame window has 0 size, so
 		// consider the window solid
+	}
+
+	if (w->frame_opacity != 1.0 && win_has_frame(w)) {
+		return WMODE_FRAME_TRANS;
 	}
 
 	// log_trace("Window %#010x(%s) is solid", w->client_win, w->name);

--- a/src/win.h
+++ b/src/win.h
@@ -418,9 +418,9 @@ struct managed_win *find_toplevel2(session_t *ps, xcb_window_t wid);
 bool attr_pure win_is_fullscreen(const session_t *ps, const struct managed_win *w);
 
 /**
- * Check if a window is really focused.
+ * Check if a window is focused, without using any focus rules or forced focus settings
  */
-bool attr_pure win_is_focused_real(const session_t *ps, const struct managed_win *w);
+bool attr_pure win_is_focused_raw(const session_t *ps, const struct managed_win *w);
 
 /// check if window has ARGB visual
 bool attr_pure win_has_alpha(const struct managed_win *w);

--- a/src/win.h
+++ b/src/win.h
@@ -107,6 +107,8 @@ struct managed_win {
 	winstate_t state;
 	/// Window attributes.
 	xcb_get_window_attributes_reply_t a;
+	/// Reply of xcb_get_geometry, which returns the geometry of the window body,
+	/// excluding the window border.
 	xcb_get_geometry_reply_t g;
 	/// Xinerama screen this window is on.
 	int xinerama_scr;


### PR DESCRIPTION
[This bug was previously reported in the yshui/picom repository.](https://github.com/yshui/picom/issues/303)

I've applied some of the commits from yshui/picom's next branch into feature/dual_kawase and they've fixed the bug on my machine.